### PR TITLE
fix: do not recreate multiaddr

### DIFF
--- a/src/address-book.ts
+++ b/src/address-book.ts
@@ -356,7 +356,7 @@ async function filterMultiaddrs (peerId: PeerId, multiaddrs: Multiaddr[], addres
     (source) => filter(source, async (multiaddr) => await addressFilter(peerId, multiaddr)),
     (source) => map(source, (multiaddr) => {
       return {
-        multiaddr: new Multiaddr(multiaddr.toString()),
+        multiaddr,
         isCertified
       }
     }),


### PR DESCRIPTION
The multiaddrs are already multiaddrs so no need to stringify and parse them again.