### PR TITLE
fix!: remove @libp2p/components

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.0",
     "@libp2p/interface-peer-id": "^1.0.4",
     "@libp2p/interface-peer-info": "^1.0.3",
     "@libp2p/interface-peer-store": "^1.2.2",
@@ -161,10 +160,10 @@
     "it-map": "^1.0.6",
     "it-pipe": "^2.0.3",
     "mortice": "^3.0.0",
-    "multiformats": "^9.6.3",
-    "protons-runtime": "^3.1.0",
+    "multiformats": "^10.0.0",
+    "protons-runtime": "^4.0.1",
     "uint8arraylist": "^2.1.1",
-    "uint8arrays": "^3.1.0"
+    "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
     "@libp2p/interface-compliance-tests": "^3.0.2",
@@ -175,7 +174,7 @@
     "delay": "^5.0.0",
     "p-defer": "^4.0.0",
     "p-wait-for": "^5.0.0",
-    "protons": "^5.1.0",
+    "protons": "^6.0.0",
     "sinon": "^14.0.0"
   }
 }

--- a/src/pb/peer.ts
+++ b/src/pb/peer.ts
@@ -1,5 +1,7 @@
 /* eslint-disable import/export */
+/* eslint-disable complexity */
 /* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -18,50 +20,48 @@ export namespace Peer {
 
   export const codec = (): Codec<Peer> => {
     if (_codec == null) {
-      _codec = message<Peer>((obj, writer, opts = {}) => {
+      _codec = message<Peer>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
         if (obj.addresses != null) {
           for (const value of obj.addresses) {
-            writer.uint32(10)
-            Address.codec().encode(value, writer)
+            w.uint32(10)
+            Address.codec().encode(value, w, {
+              writeDefaults: true
+            })
           }
-        } else {
-          throw new Error('Protocol error: required field "addresses" was not found in object')
         }
 
         if (obj.protocols != null) {
           for (const value of obj.protocols) {
-            writer.uint32(18)
-            writer.string(value)
+            w.uint32(18)
+            w.string(value)
           }
-        } else {
-          throw new Error('Protocol error: required field "protocols" was not found in object')
         }
 
         if (obj.metadata != null) {
           for (const value of obj.metadata) {
-            writer.uint32(26)
-            Metadata.codec().encode(value, writer)
+            w.uint32(26)
+            Metadata.codec().encode(value, w, {
+              writeDefaults: true
+            })
           }
-        } else {
-          throw new Error('Protocol error: required field "metadata" was not found in object')
         }
 
         if (obj.pubKey != null) {
-          writer.uint32(34)
-          writer.bytes(obj.pubKey)
+          w.uint32(34)
+          w.bytes(obj.pubKey)
         }
 
         if (obj.peerRecordEnvelope != null) {
-          writer.uint32(42)
-          writer.bytes(obj.peerRecordEnvelope)
+          w.uint32(42)
+          w.bytes(obj.peerRecordEnvelope)
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -123,25 +123,23 @@ export namespace Address {
 
   export const codec = (): Codec<Address> => {
     if (_codec == null) {
-      _codec = message<Address>((obj, writer, opts = {}) => {
+      _codec = message<Address>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
-        if (obj.multiaddr != null) {
-          writer.uint32(10)
-          writer.bytes(obj.multiaddr)
-        } else {
-          throw new Error('Protocol error: required field "multiaddr" was not found in object')
+        if (opts.writeDefaults === true || (obj.multiaddr != null && obj.multiaddr.byteLength > 0)) {
+          w.uint32(10)
+          w.bytes(obj.multiaddr)
         }
 
         if (obj.isCertified != null) {
-          writer.uint32(16)
-          writer.bool(obj.isCertified)
+          w.uint32(16)
+          w.bool(obj.isCertified)
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -164,10 +162,6 @@ export namespace Address {
               reader.skipType(tag & 7)
               break
           }
-        }
-
-        if (obj.multiaddr == null) {
-          throw new Error('Protocol error: value for required field "multiaddr" was not found in protobuf')
         }
 
         return obj
@@ -196,27 +190,23 @@ export namespace Metadata {
 
   export const codec = (): Codec<Metadata> => {
     if (_codec == null) {
-      _codec = message<Metadata>((obj, writer, opts = {}) => {
+      _codec = message<Metadata>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
-        if (obj.key != null) {
-          writer.uint32(10)
-          writer.string(obj.key)
-        } else {
-          throw new Error('Protocol error: required field "key" was not found in object')
+        if (opts.writeDefaults === true || obj.key !== '') {
+          w.uint32(10)
+          w.string(obj.key)
         }
 
-        if (obj.value != null) {
-          writer.uint32(18)
-          writer.bytes(obj.value)
-        } else {
-          throw new Error('Protocol error: required field "value" was not found in object')
+        if (opts.writeDefaults === true || (obj.value != null && obj.value.byteLength > 0)) {
+          w.uint32(18)
+          w.bytes(obj.value)
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -240,14 +230,6 @@ export namespace Metadata {
               reader.skipType(tag & 7)
               break
           }
-        }
-
-        if (obj.key == null) {
-          throw new Error('Protocol error: value for required field "key" was not found in protobuf')
-        }
-
-        if (obj.value == null) {
-          throw new Error('Protocol error: value for required field "value" was not found in protobuf')
         }
 
         return obj

--- a/src/pb/tags.ts
+++ b/src/pb/tags.ts
@@ -1,5 +1,7 @@
 /* eslint-disable import/export */
+/* eslint-disable complexity */
 /* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare */
 
 import { encodeMessage, decodeMessage, message } from 'protons-runtime'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -14,22 +16,22 @@ export namespace Tags {
 
   export const codec = (): Codec<Tags> => {
     if (_codec == null) {
-      _codec = message<Tags>((obj, writer, opts = {}) => {
+      _codec = message<Tags>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
         if (obj.tags != null) {
           for (const value of obj.tags) {
-            writer.uint32(10)
-            Tag.codec().encode(value, writer)
+            w.uint32(10)
+            Tag.codec().encode(value, w, {
+              writeDefaults: true
+            })
           }
-        } else {
-          throw new Error('Protocol error: required field "tags" was not found in object')
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -78,30 +80,28 @@ export namespace Tag {
 
   export const codec = (): Codec<Tag> => {
     if (_codec == null) {
-      _codec = message<Tag>((obj, writer, opts = {}) => {
+      _codec = message<Tag>((obj, w, opts = {}) => {
         if (opts.lengthDelimited !== false) {
-          writer.fork()
+          w.fork()
         }
 
-        if (obj.name != null) {
-          writer.uint32(10)
-          writer.string(obj.name)
-        } else {
-          throw new Error('Protocol error: required field "name" was not found in object')
+        if (opts.writeDefaults === true || obj.name !== '') {
+          w.uint32(10)
+          w.string(obj.name)
         }
 
         if (obj.value != null) {
-          writer.uint32(16)
-          writer.uint32(obj.value)
+          w.uint32(16)
+          w.uint32(obj.value)
         }
 
         if (obj.expiry != null) {
-          writer.uint32(24)
-          writer.uint64(obj.expiry)
+          w.uint32(24)
+          w.uint64(obj.expiry)
         }
 
         if (opts.lengthDelimited !== false) {
-          writer.ldelim()
+          w.ldelim()
         }
       }, (reader, length) => {
         const obj: any = {
@@ -127,10 +127,6 @@ export namespace Tag {
               reader.skipType(tag & 7)
               break
           }
-        }
-
-        if (obj.name == null) {
-          throw new Error('Protocol error: value for required field "name" was not found in protobuf')
         }
 
         return obj

--- a/test/address-book.spec.ts
+++ b/test/address-book.spec.ts
@@ -13,7 +13,6 @@ import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { AddressBook } from '@libp2p/interface-peer-store'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { Components } from '@libp2p/components'
 
 const addr1 = multiaddr('/ip4/127.0.0.1/tcp/8000')
 const addr2 = multiaddr('/ip4/20.0.0.1/tcp/8001')
@@ -31,8 +30,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       ab = peerStore.addressBook
     })
 
@@ -149,8 +147,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       ab = peerStore.addressBook
     })
 
@@ -304,8 +301,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       ab = peerStore.addressBook
     })
 
@@ -342,8 +338,7 @@ describe('addressBook', () => {
     let ab: AddressBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       ab = peerStore.addressBook
     })
 
@@ -400,8 +395,7 @@ describe('addressBook', () => {
 
     describe('consumes a valid peer record and stores its data', () => {
       beforeEach(() => {
-        peerStore = new PersistentPeerStore()
-        peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+        peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
         ab = peerStore.addressBook
       })
 
@@ -602,8 +596,7 @@ describe('addressBook', () => {
 
     describe('fails to consume invalid peer records', () => {
       beforeEach(() => {
-        peerStore = new PersistentPeerStore()
-        peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+        peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
         ab = peerStore.addressBook
       })
 

--- a/test/key-book.spec.ts
+++ b/test/key-book.spec.ts
@@ -9,7 +9,6 @@ import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { KeyBook } from '@libp2p/interface-peer-store'
-import { Components } from '@libp2p/components'
 
 describe('keyBook', () => {
   let peerId: PeerId
@@ -20,8 +19,7 @@ describe('keyBook', () => {
   beforeEach(async () => {
     peerId = await createEd25519PeerId()
     datastore = new MemoryDatastore()
-    peerStore = new PersistentPeerStore()
-    peerStore.init(new Components({ peerId, datastore }))
+    peerStore = new PersistentPeerStore({ peerId, datastore })
     kb = peerStore.keyBook
   })
 

--- a/test/metadata-book.spec.ts
+++ b/test/metadata-book.spec.ts
@@ -10,7 +10,6 @@ import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { MetadataBook } from '@libp2p/interface-peer-store'
-import { Components } from '@libp2p/components'
 
 describe('metadataBook', () => {
   let peerId: PeerId
@@ -24,8 +23,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       mb = peerStore.metadataBook
     })
 
@@ -162,8 +160,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       mb = peerStore.metadataBook
     })
 
@@ -203,8 +200,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       mb = peerStore.metadataBook
     })
 
@@ -254,8 +250,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       mb = peerStore.metadataBook
     })
 
@@ -310,8 +305,7 @@ describe('metadataBook', () => {
     let mb: MetadataBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       mb = peerStore.metadataBook
     })
 

--- a/test/peer-store.spec.ts
+++ b/test/peer-store.spec.ts
@@ -7,7 +7,6 @@ import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { MemoryDatastore } from 'datastore-core/memory'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import { Components } from '@libp2p/components'
 import delay from 'delay'
 
 const addr1 = multiaddr('/ip4/127.0.0.1/tcp/8000')
@@ -35,8 +34,7 @@ describe('peer-store', () => {
     let peerStore: PersistentPeerStore
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId: peerIds[4], datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId: peerIds[4], datastore: new MemoryDatastore() })
     })
 
     it('has an empty map of peers', async () => {
@@ -65,8 +63,7 @@ describe('peer-store', () => {
     let peerStore: PersistentPeerStore
 
     beforeEach(async () => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId: peerIds[4], datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId: peerIds[4], datastore: new MemoryDatastore() })
 
       // Add peer0 with { addr1, addr2 } and { proto1 }
       await peerStore.addressBook.set(peerIds[0], [addr1, addr2])
@@ -166,8 +163,7 @@ describe('peer-store', () => {
     let peerStore: PersistentPeerStore
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId: peerIds[4], datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId: peerIds[4], datastore: new MemoryDatastore() })
     })
 
     it('returns peers if only addresses are known', async () => {
@@ -220,8 +216,7 @@ describe('peer-store', () => {
     let peerStore: PersistentPeerStore
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId: peerIds[4], datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId: peerIds[4], datastore: new MemoryDatastore() })
     })
 
     it('tags a peer', async () => {

--- a/test/proto-book.spec.ts
+++ b/test/proto-book.spec.ts
@@ -10,7 +10,6 @@ import { codes } from '../src/errors.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { ProtoBook } from '@libp2p/interface-peer-store'
-import { Components } from '@libp2p/components'
 
 const arraysAreEqual = (a: string[], b: string[]) => {
   if (a.length !== b.length) {
@@ -32,8 +31,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       pb = peerStore.protoBook
     })
 
@@ -125,8 +123,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       pb = peerStore.protoBook
     })
 
@@ -229,8 +226,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       pb = peerStore.protoBook
     })
 
@@ -315,8 +311,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       pb = peerStore.protoBook
     })
 
@@ -346,8 +341,7 @@ describe('protoBook', () => {
     let pb: ProtoBook
 
     beforeEach(() => {
-      peerStore = new PersistentPeerStore()
-      peerStore.init(new Components({ peerId, datastore: new MemoryDatastore() }))
+      peerStore = new PersistentPeerStore({ peerId, datastore: new MemoryDatastore() })
       pb = peerStore.protoBook
     })
 


### PR DESCRIPTION
`@libp2p/components` is a choke-point for our dependency graph as it depends on every interface, meaning when one interface revs a major `@libp2p/components` major has to change too which means every module depending on it also needs a major.

Switch instead to constructor injection of simple objects that let modules declare their dependencies on interfaces directly instead of indirectly via `@libp2p/components`

Refs https://github.com/libp2p/js-libp2p-components/issues/6

BREAKING CHANGE: modules no longer implement `Initializable` instead switching to constructor injection