### PR TITLE
fix: allow overwriting tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,11 +135,8 @@ export class PersistentPeerStore extends EventEmitter<PeerStoreEvents> implement
       tags = Tags.decode(buf).tags
     }
 
-    for (const t of tags) {
-      if (t.name === tag) {
-        throw new CodeError('Peer already tagged', 'ERR_DUPLICATE_TAG')
-      }
-    }
+    // do not allow duplicate tags
+    tags = tags.filter(t => t.name !== tag)
 
     tags.push({
       name: tag,

--- a/test/peer-store.spec.ts
+++ b/test/peer-store.spec.ts
@@ -288,10 +288,18 @@ describe('peer-store', () => {
 
     it('does not tag a peer twice', async () => {
       const name = 'a-tag'
-      await peerStore.tagPeer(peerIds[0], name)
+      await peerStore.tagPeer(peerIds[0], name, {
+        value: 1
+      })
+      await peerStore.tagPeer(peerIds[0], name, {
+        value: 10
+      })
 
-      await expect(peerStore.tagPeer(peerIds[0], name), 'PeerStore allowed duplicate tags')
-        .to.eventually.be.rejected().with.property('code', 'ERR_DUPLICATE_TAG')
+      const allTags = await peerStore.getTags(peerIds[0])
+      const tags = allTags.filter(t => t.name === name)
+
+      expect(tags).to.have.lengthOf(1)
+      expect(tags).to.have.nested.property('[0].value', 10)
     })
 
     it('untags a peer', async () => {


### PR DESCRIPTION
Allows setting the same tag twice, last update wins. Otherwise trying to ensure atomic writes becomes very hard.