### PR TITLE
feat: add consume peer record method

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.7",
     "@libp2p/peer-id": "^2.0.0",
+    "@libp2p/peer-record": "^5.0.3",
     "@multiformats/multiaddr": "^12.0.0",
     "interface-datastore": "^8.0.0",
     "mortice": "^3.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import type { Datastore } from 'interface-datastore'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Libp2pEvents } from '@libp2p/interface-libp2p'
 import { logger } from '@libp2p/logger'
+import { RecordEnvelope, PeerRecord } from '@libp2p/peer-record'
 
 const log = logger('libp2p:peer-store')
 
@@ -162,6 +163,48 @@ export class PersistentPeerStore implements PeerStore {
       log.trace('merge release write lock')
       release()
     }
+  }
+
+  async consumePeerRecord (buf: Uint8Array, expectedPeer?: PeerId): Promise<boolean> {
+    const envelope = await RecordEnvelope.openAndCertify(buf, PeerRecord.DOMAIN)
+
+    if (expectedPeer?.equals(envelope.peerId) === false) {
+      log('envelope peer id was not the expected peer id - expected: %p received: %p', expectedPeer, envelope.peerId)
+      return false
+    }
+
+    const peerRecord = PeerRecord.createFromProtobuf(envelope.payload)
+    let peer: Peer | undefined
+
+    try {
+      peer = await this.get(envelope.peerId)
+    } catch (err: any) {
+      if (err.code !== 'ERR_NOT_FOUND') {
+        throw err
+      }
+    }
+
+    // ensure seq is greater than, or equal to, the last received
+    if (peer?.peerRecordEnvelope != null) {
+      const storedEnvelope = await RecordEnvelope.createFromProtobuf(peer.peerRecordEnvelope)
+      const storedRecord = PeerRecord.createFromProtobuf(storedEnvelope.payload)
+
+      // ensure seq is greater than, or equal to, the last received
+      if (storedRecord.seqNumber >= peerRecord.seqNumber) {
+        log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
+        return false
+      }
+    }
+
+    await this.patch(peerRecord.peerId, {
+      peerRecordEnvelope: buf,
+      addresses: peerRecord.multiaddrs.map(multiaddr => ({
+        isCertified: true,
+        multiaddr
+      }))
+    })
+
+    return true
   }
 
   #emitIfUpdated (id: PeerId, result: PeerUpdate): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,6 @@ export class PersistentPeerStore implements PeerStore {
       const storedEnvelope = await RecordEnvelope.createFromProtobuf(peer.peerRecordEnvelope)
       const storedRecord = PeerRecord.createFromProtobuf(storedEnvelope.payload)
 
-      // ensure seq is greater than, or equal to, the last received
       if (storedRecord.seqNumber >= peerRecord.seqNumber) {
         log('sequence number was lower or equal to existing sequence number - stored: %d received: %d', storedRecord.seqNumber, peerRecord.seqNumber)
         return false


### PR DESCRIPTION
Add method to patch peer info with certified addresses extracted from a signed peer record.

This is used by gossipsub.