### PR TITLE
deps: move @libp2p/peer-id-factory to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@libp2p/interfaces": "^3.2.0",
     "@libp2p/logger": "^2.0.7",
     "@libp2p/peer-id": "^2.0.0",
+    "@libp2p/peer-id-factory": "^2.0.0",
     "@libp2p/peer-record": "^5.0.3",
     "@multiformats/multiaddr": "^12.0.0",
     "interface-datastore": "^8.0.0",
@@ -161,7 +162,6 @@
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
-    "@libp2p/peer-id-factory": "^2.0.0",
     "@types/sinon": "^10.0.14",
     "aegir": "^39.0.5",
     "datastore-core": "^9.0.1",


### PR DESCRIPTION
We use @libp2p/peer-id-factory export function at: https://github.com/libp2p/js-libp2p-peer-store/blob/master/src/utils/bytes-to-peer.ts#L2

so move it to dependencies.